### PR TITLE
Fix #21 -- update import path for mlc_chat function

### DIFF
--- a/llm_mlc.py
+++ b/llm_mlc.py
@@ -254,7 +254,10 @@ class MlcModel(llm.Model):
     def execute(self, prompt, stream, response, conversation):
         try:
             import mlc_chat
-            from mlc_chat.callback import _get_delta_message as get_delta_message
+            try:
+                from mlc_chat.callback import _get_delta_message as get_delta_message
+            except ImportError:  # older versions of mlc_chat
+                from mlc_chat.base import get_delta_message
             import mlc_chat.chat_module
         except ImportError:
             raise click.ClickException(MLC_INSTALL)

--- a/llm_mlc.py
+++ b/llm_mlc.py
@@ -254,7 +254,7 @@ class MlcModel(llm.Model):
     def execute(self, prompt, stream, response, conversation):
         try:
             import mlc_chat
-            from mlc_chat.base import get_delta_message
+            from mlc_chat.callback import _get_delta_message as get_delta_message
             import mlc_chat.chat_module
         except ImportError:
             raise click.ClickException(MLC_INSTALL)


### PR DESCRIPTION
Greetings, Simon!

I noticed that the current version of `llm-mlc` does not work due to the changes made in mlc-ai, specifically in this PR:
https://github.com/mlc-ai/mlc-llm/pull/1502/

`get_delta_message` became private, so I am not sure if we want to rely on this, but as a hotfix, I felt this might be acceptable.

For a long-term solution, I guess we'd need to switch to using `[StreamToStdout](https://github.com/mlc-ai/mlc-llm/blob/ac57c03ccc1ec8e9d8079d6577c5c135dd80bec0/python/mlc_chat/callback.py#L72)`, but I did not feel comfortable (familiar with the codebases etc.) to make a bigger change yet.

Happy to hear your thoughts.

Best,
Rust
